### PR TITLE
Use latest arteria-core

### DIFF
--- a/requirements/prod
+++ b/requirements/prod
@@ -3,5 +3,5 @@ tornado==4.2.1
 git+https://github.com/dakl/localq.git@v0.3.7
 # Localq depence on networkx
 networkx==1.11
-git+https://github.com/arteria-project/arteria-core.git@v1.0.1#egg=arteria-core
+git+https://github.com/arteria-project/arteria-core.git@v1.1.0#egg=arteria-core
 


### PR DESCRIPTION
This just bumps the version used for `arteria-core` to the latest available (1.1.0), that was released over a year ago.  :see_no_evil: 

Haven't tested the latest version with this Arteria service, but the "new" version only includes a new function that can validate the state of a runfolder, and adds a new state `ready` that can be used: https://github.com/arteria-project/arteria-core/compare/v1.0.1...master so shouldn't be a problem. 